### PR TITLE
Multiple fmt strings

### DIFF
--- a/examples/wrapper.rs
+++ b/examples/wrapper.rs
@@ -1,0 +1,47 @@
+//! Sometimes, you might want to wrap bunt's macros into your own
+//! project-specific macro. Often, you want to print a prefix or something like
+//! that.
+
+
+macro_rules! log {
+    ($fmt:literal $(, $arg:expr)* $(,)?) => {
+        bunt::println!(
+            // Bunt macros allow to pass an "array" of format strings which are
+            // then concatenated by bunt.
+            [
+                // Our prefix
+                "[{[magenta] log_module_path}] ",
+                // What the user passed
+                $fmt,
+                // Our postfix
+                " {$cyan}({log_file}:{log_line}){/$}",
+            ],
+            $($arg ,)*
+            log_module_path = std::module_path!(),
+            log_file = std::file!(),
+            log_line = std::line!(),
+        )
+
+        // This solution is not optimal though. For one, it would be nice to
+        // `stringify!(std::module_path!())` instead of passing it as runtime
+        // string argument. That's not possible because macro expansions are
+        // lazy.
+        //
+        // Futhermore, we pass the arguments with names like `log_module_path`.
+        // In theory, the user could also use a named argument with that name.
+        // This `log!` macro is very much an internal helper macro and not
+        // something you would want to put into your public API.
+    };
+}
+
+
+fn main() {
+    log!("Hello {}", "peter");
+    banana::do_something();
+}
+
+mod banana {
+    pub fn do_something() {
+        log!("I'm doing something with {[yellow]:?}", vec![1, 2, 4]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,29 @@
 //! want to give your users the choice of color usage, e.g. via a `--color` CLI
 //! argument.
 //!
+//!
+//! # Passing multiple format strings (`concat!` replacement)
+//!
+//! In many cases, users wish to call `concat!` and pass the result as format
+//! string to bunt's macros, e.g. `bunt::println!(concat!("foo", "bar"))`. This
+//! is mainly used if you want to write your own macro to wrap bunt's macros.
+//! Unfortunately, this is not easily possible as macros are expaned lazily. See
+//! [issue #15](https://github.com/LukasKalbertodt/bunt/issues/15) for more
+//! information.
+//!
+//! As a workaround for this fairly common use case, bunt allows passing an
+//! "array of format strings", like so:
+//!
+//! ```
+//! bunt::println!(["foo ", "{[red]} bar"], 27);
+//! ```
+//!
+//! All given strings will be concatenated by `bunt`. So the above code is
+//! equivalent to `bunt::println!("foo {[red]} bar", 27)`.
+//!
+//! For most users this feature is irrelevant. If possible, pass the format
+//! string as single string literal.
+//!
 
 #![deny(intra_doc_link_resolution_failure)]
 
@@ -152,8 +175,11 @@ pub extern crate bunt_macros;
 #[macro_export]
 macro_rules! write {
     ($target:expr, $format_str:literal $(, $arg:expr)* $(,)?) => {
+        $crate::write!($target, [$format_str] $(, $arg )*)
+    };
+    ($target:expr, [$($format_str:literal),+ $(,)?] $(, $arg:expr)* $(,)?) => {
         $crate::bunt_macros::write!(
-            $target $format_str $( $arg )*
+            $target [$($format_str)+] $( $arg )*
         )
     };
 }
@@ -175,8 +201,11 @@ macro_rules! write {
 #[macro_export]
 macro_rules! writeln {
     ($target:expr, $format_str:literal $(, $arg:expr)* $(,)?) => {
+        $crate::writeln!($target, [$format_str] $(, $arg )*)
+    };
+    ($target:expr, [$($format_str:literal),+ $(,)?] $(, $arg:expr)* $(,)?) => {
         $crate::bunt_macros::writeln!(
-            $target $format_str $( $arg )*
+            $target [$($format_str)+] $( $arg )*
         )
     };
 }
@@ -196,9 +225,12 @@ macro_rules! writeln {
 #[macro_export]
 macro_rules! print {
     ($format_str:literal $(, $arg:expr)* $(,)?) => {
+        $crate::print!([$format_str] $(, $arg )*)
+    };
+    ([$($format_str:literal),+ $(,)?] $(, $arg:expr)* $(,)?) => {
         $crate::bunt_macros::write!(
             ($crate::termcolor::StandardStream::stdout($crate::termcolor::ColorChoice::Auto))
-            $format_str $( $arg )*
+            [$($format_str)+] $( $arg )*
         ).expect("failed to write to stdout in `bunt::print`")
     };
 }
@@ -215,9 +247,12 @@ macro_rules! print {
 #[macro_export]
 macro_rules! println {
     ($format_str:literal $(, $arg:expr)* $(,)?) => {
+        $crate::println!([$format_str] $(, $arg )*)
+    };
+    ([$($format_str:literal),+ $(,)?] $(, $arg:expr)* $(,)?) => {
         $crate::bunt_macros::writeln!(
             ($crate::termcolor::StandardStream::stdout($crate::termcolor::ColorChoice::Auto))
-            $format_str $( $arg )*
+            [$($format_str)+] $( $arg )*
         ).expect("failed to write to stdout in `bunt::println`")
     };
 }
@@ -237,9 +272,12 @@ macro_rules! println {
 #[macro_export]
 macro_rules! eprint {
     ($format_str:literal $(, $arg:expr)* $(,)?) => {
+        $crate::eprint!([$format_str] $(, $arg )*)
+    };
+    ([$($format_str:literal),+ $(,)?] $(, $arg:expr)* $(,)?) => {
         $crate::bunt_macros::write!(
             ($crate::termcolor::StandardStream::stderr($crate::termcolor::ColorChoice::Auto))
-            $format_str $( $arg )*
+            [$($format_str)+] $( $arg )*
         ).expect("failed to write to stderr in `bunt::eprint`")
     };
 }
@@ -256,9 +294,12 @@ macro_rules! eprint {
 #[macro_export]
 macro_rules! eprintln {
     ($format_str:literal $(, $arg:expr)* $(,)?) => {
+        $crate::eprintln!([$format_str] $(, $arg )*)
+    };
+    ([$($format_str:literal),+ $(,)?] $(, $arg:expr)* $(,)?) => {
         $crate::bunt_macros::writeln!(
             ($crate::termcolor::StandardStream::stderr($crate::termcolor::ColorChoice::Auto))
-            $format_str $( $arg )*
+            [$($format_str)+] $( $arg )*
         ).expect("failed to write to stderr in `bunt::eprintln`")
     };
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use bunt::{
-    write, writeln, print, println,
+    write, writeln, print, println, eprint, eprintln,
     termcolor::Buffer,
 };
 
@@ -304,4 +304,30 @@ fn set_color_error() {
     let res = bunt::write!(b, "{$green}colooor{/$}");
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), io::ErrorKind::NotFound);
+}
+
+#[test]
+fn concat_fmt_strings() {
+    check!("hello" == ["hello"]);
+    check!("hello" == ["hello",]);
+    check!("foobar" == ["foo", "bar"]);
+    check!("foobar" == ["foo", "bar",]);
+    check!("foo 27 bar" == ["foo ", "{} bar"], 27);
+    check!("abtruecd" == ["a", "b", "{}", "c", "d"], true);
+
+    check!(
+        "a\nb\tc\rd\0e\x48f\u{50}g\u{228}h\u{fffe}i\u{1F923}j" ==
+        ["a\n", "b\tc\r", "d\0e\x48f\u{50}", "g\u{228}h\u{fffe}i", "\u{1F923}j"]
+    );
+}
+
+#[test]
+fn concat_fmt_strings_all_strings() {
+    let mut b = buf();
+    let _ = write!(b, ["a", "{} b"], 27);
+    let _ = writeln!(b, ["a", "{} b"], 27);
+    print!(["a", "{} \r"], 27);
+    eprint!(["a", "{} \r"], 27);
+    println!(["", "{}"], "");
+    eprintln!(["", "{}"], "");
 }


### PR DESCRIPTION
Closes #15  

This is a workaround for the use cases where you want to pass the result of `concat!` as format string. 

@d4h0 Again, if you have the time, I would appreciate feedback if this works for your use case. I will test a similar use case in an app of mine soon-ish, too.