### PR TITLE
Allow `println`, `eprintln` & `writeln` to be used without format string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,9 @@ macro_rules! writeln {
             $target [$($format_str)+] $( $arg )*
         )
     };
+    ($target:expr $(,)?) => {
+        $crate::writeln!($target, "")
+    };
 }
 
 /// Writes formatted data to stdout (with `ColorChoice::Auto`).
@@ -255,6 +258,9 @@ macro_rules! println {
             [$($format_str)+] $( $arg )*
         ).expect("failed to write to stdout in `bunt::println`")
     };
+    () => {
+        std::println!()
+    };
 }
 
 /// Writes formatted data to stderr (with `ColorChoice::Auto`).
@@ -301,6 +307,9 @@ macro_rules! eprintln {
             ($crate::termcolor::StandardStream::stderr($crate::termcolor::ColorChoice::Auto))
             [$($format_str)+] $( $arg )*
         ).expect("failed to write to stderr in `bunt::eprintln`")
+    };
+    () => {
+        std::eprintln!()
     };
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -111,6 +111,19 @@ fn no_move_args() {
 }
 
 #[test]
+fn empty_ln() {
+    // Just make sure they compile, we cannot easily capture and test their output.
+    println!();
+    eprintln!();
+
+
+    let mut b = buf();
+    writeln!(b).unwrap();
+    writeln!(b,).unwrap();
+    assert_eq!(raw_str(&b), "\n\n");
+}
+
+#[test]
 fn arg_referal() {
     check!("27" == "{peter}", peter = 27);
     check!("27 27" == "{0} {0}", 27);


### PR DESCRIPTION
In that case, they only print/write the newline. This puts them more in line with `std`'s macros.

Fixes #23